### PR TITLE
Travis CI: Revert travis current configurations to previous configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,77 @@
-language: node_js
-node_js:
-  - 10
+# Travis CI build configuration for MediaWiki
+# <https://travis-ci.org/wikimedia/mediawiki-core>
+#
+# The Wikimedia Foundation uses a self-hosted Jenkins instance to run unit
+# tests, but it tests code against the version of PHP that is deployed on
+# Wikimedia's production cluster. This Travis CI configuration is designed to
+# complement that setup by testing MediaWiki on travis
+#
+language: php
+
+# Use Ubuntu 14 Trusty (not Ubuntu 12 Precise)
+# <https://docs.travis-ci.com/user/reference/trusty/>
+# - Required for non-buggy xml library for XmlTypeCheck/UploadBaseTest (T75176).
+dist: trusty
+
+# Cache NPM and Composer directories
+# <https://docs.travis-ci.com/user/caching/>
+cache:
+  npm: true
+  directories:
+  # Composer doesn't have a dedicated cache setting in Travis CI config, so set the directory path instead.
+  - vendor
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
 
 services:
-  - docker
+  - mysql
 
-script:  
-  - npm ci
-  - npm run lint
-  - npm run playwright:silent
+branches:
+  # Test changes in master and arbitrary Travis CI branches only.
+  # The latter allows developers to enable Travis CI in their GitHub fork of
+  # wikimedia/mediawiki and then push changes for testing to branches like
+  # "travis-ci/test-this-awesome-change".
+  only:
+    - master
+    - /^travis-ci\/.*$/
+
+addons:
+  apt:
+    packages:
+    - djvulibre-bin
+    - tidy
+
+before_script:
+  - echo 'opcache.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  # Force composer 1.x because MediaWiki/composer-merge-plugin don't support composer 2.x yet
+  - composer self-update --1
+  - composer install --prefer-source --quiet --no-interaction
+  # At Travis CI, the mysql user 'travis' doesn't have create database rights, use 'root' instead.
+  - >
+      php maintenance/install.php traviswiki admin
+      --pass somemwadminpassword
+      --dbtype "mysql"
+      --dbname traviswiki
+      --dbuser "root"
+      --dbpass ""
+      --scriptpath "/w"
+  - echo -en "\n\nrequire_once __DIR__ . '/includes/DevelopmentSettings.php';\n" >> ./LocalSettings.php
+  - php -l ./LocalSettings.php
+
+script:
+  - php tests/phpunit/phpunit.php
+
+notifications:
+  email: false
+  irc:
+    channels:
+      - "chat.freenode.net#wikimedia-dev"
+    template:
+      - "%{repository}#%{build_number} (%{branch} - %{commit} %{author}): %{message} - %{build_url}"
+    on_success: change
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/hariclerry/mediawiki.svg?branch=master)](https://travis-ci.org/hariclerry/mediawiki)
-
 # MediaWiki
 
 MediaWiki is a free and open-source wiki software package written in PHP. It


### PR DESCRIPTION
### Tickets
Closes #22

### What does this PR do?
This PR removes nodejs config from .travis.yml file, reverts the file to the previous state, and adds remove travis ci status badge to the README file

### What are the changes made?
- Remove Node configuration from travis.yml file
- Added previous configurations to the file
- Remove travis CI status badge from the Readme file

### Screen shots
None