### PR TITLE
Mediawiki-docker: Configure mediawiki-docker to run on github actions

### DIFF
--- a/.github/workflows/docker_compose_override.sh
+++ b/.github/workflows/docker_compose_override.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -l
+echo "version: '3.7'
+services:
+  mediawiki:
+    user: '$1:$2'" > /home/runner/work/mediawiki/mediawiki/docker-compose.override.yml

--- a/.github/workflows/env_variables.sh
+++ b/.github/workflows/env_variables.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -l
+echo "MW_DOCKER_PORT=8080
+MW_SCRIPT_PATH=/w
+MW_SERVER=http://localhost:8080
+MEDIAWIKI_USER=Admin
+MEDIAWIKI_PASSWORD=dockerpass
+XDEBUG_CONFIG=""
+MW_DOCKER_UID=$(id -u)
+MW_DOCKER_GID=$(id -g)" >> $1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,8 +10,28 @@ on:
         branches: [master]
 
 jobs:
-    test:
+    vector_skin:
         runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: "Clone vector skin repository"
+              run: |
+                  git clone "https://gerrit.wikimedia.org/r/mediawiki/skins/Vector" skins/Vector
+            - name: "Add vector skin config to LocalSettings.php file"
+              run: |
+                  echo "wfLoadSkin( 'Vector' );" >> LocalSettings.php
+
+    test:
+        env:
+            MW_DOCKER_PORT: 8080
+            MW_SCRIPT_PATH: /w
+            MW_SERVER: http://localhost:8080
+            MEDIAWIKI_USER: Admin
+            MEDIAWIKI_PASSWORD: dockerpass
+            XDEBUG_CONFIG: ""
+        runs-on: ubuntu-latest
+        needs: vector_skin
 
         strategy:
             matrix:
@@ -29,6 +49,10 @@ jobs:
             - name: "Run eslint"
               run: |
                   npm run lint
+            - name: Setup mediawiki-docker
+              run: |
+                  docker-compose up -d
+                  docker ps -a
             - name: "Run playwright tests"
               run: |
                   npm run playwright:silent

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,53 +10,43 @@ on:
         branches: [master]
 
 jobs:
-    vector_skin:
-        runs-on: macos-latest
-
-        steps:
-            - uses: actions/checkout@v2
-            - name: "Clone vector skin repository"
-              run: |
-                  git clone "https://gerrit.wikimedia.org/r/mediawiki/skins/Vector" skins/Vector
-            - name: "Add vector skin config to LocalSettings.php file"
-              run: |
-                  echo "wfLoadSkin( 'Vector' );" >> LocalSettings.php
-
     test:
-        env:
-            MW_DOCKER_PORT: 8080
-            MW_SCRIPT_PATH: /w
-            MW_SERVER: http://localhost:8080
-            MEDIAWIKI_USER: Admin
-            MEDIAWIKI_PASSWORD: dockerpass
-            XDEBUG_CONFIG: ""
-        runs-on: macos-latest
-        needs: vector_skin
-
+        runs-on: ubuntu-latest
         strategy:
             matrix:
                 node-version: [10.x]
-
         steps:
             - uses: actions/checkout@v2
-            - name: Use Node.js ${{ matrix.node-version }}
+            - name: "Use Node.js ${{ matrix.node-version }}"
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: "Install dependencies"
+
+            - name: "Add environment variables to env file"
               run: |
-                  npm ci
-            - name: "Run eslint"
+                  $(pwd)/.github/workflows/env_variables.sh $GITHUB_ENV
+            - name: "Clone vector skin repository"
               run: |
-                  npm run lint
-            - name: Install docker
+                  git clone "https://gerrit.wikimedia.org/r/mediawiki/skins/Vector" skins/Vector
+            - name: "Add docker-compose.override.yml"
               run: |
-                 brew install docker docker-machine docker-compose
-                 sudo docker –version
-            - name: Setup mediawiki-docker
+                  $(pwd)/.github/workflows/docker_compose_override.sh ${{ env.MW_DOCKER_UID }} ${{ env.MW_DOCKER_GID }}
+            - name: "Setup mediawiki-docker"
               run: |
                   docker-compose up -d
                   docker ps -a
+                  docker-compose exec -T mediawiki composer update
+                  docker-compose exec -T mediawiki /bin/bash /docker/install.sh
+            - name: "Add vector skin config to LocalSettings.php file"
+              run: |
+                  sudo bash -c "echo 'wfLoadSkin( 'Vector' );' >> LocalSettings.php"
+            - name: "Install dependencies & Run eslint"
+              run: |
+                  npm ci
+                  npm run lint
             - name: "Run playwright tests"
               run: |
                   npm run playwright:silent
+            - name: "Run wikimdia on localhost"
+              run: |
+                  curl http://localhost:8080/

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     vector_skin:
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
 
         steps:
             - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
             MEDIAWIKI_USER: Admin
             MEDIAWIKI_PASSWORD: dockerpass
             XDEBUG_CONFIG: ""
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         needs: vector_skin
 
         strategy:
@@ -49,6 +49,10 @@ jobs:
             - name: "Run eslint"
               run: |
                   npm run lint
+            - name: Install docker
+              run: |
+                 brew install docker docker-machine docker-compose
+                 sudo docker –version
             - name: Setup mediawiki-docker
               run: |
                   docker-compose up -d


### PR DESCRIPTION
### Tickets
Closes #30 

### What does this PR do?
This PR configures GitHub actions to run  mediawiki-docker

### What are the changes made?
- Added commands to run  mediawiki-docker 

### Screen shots
None